### PR TITLE
Fix initial run fail and allow JRE to be specified

### DIFF
--- a/gocd/map.jinja
+++ b/gocd/map.jinja
@@ -1,10 +1,11 @@
 {% from 'java/map.jinja' import java with context %}
 {% import_yaml 'gocd/defaults.yaml' as default_settings %}
 {% set gocd = salt['pillar.get']('gocd', default=default_settings.get('gocd'), merge=True) %}
+{% set java_env = salt['pillar.get']('java:env', default='jre7') %}
 
 {% do gocd.server.config.update({
-  'JAVA_HOME': java.jre7.home
+  'JAVA_HOME': java[java_env].home
 }) %}
 {% do gocd.agent.config.update({
-  'JAVA_HOME': java.jre7.home
+  'JAVA_HOME': java[java_env].home
 }) %}

--- a/gocd/server.sls
+++ b/gocd/server.sls
@@ -41,6 +41,8 @@ go-server-plugins-external-clean:
     - clean: True
     - watch_in:
       - service: go-server
+    - require:
+      - file: go-server-plugins-external
 
 {% for jar, url in gocd.server.get('plugins', {}).items() %}
 {% set destination = gocd.server.config.SERVER_WORK_DIR + '/plugins/external/' + jar + '.jar' %}


### PR DESCRIPTION
Initial run attempts to clean the plugins directory before it's created, so this PR establishes that relationship.
Additionally, the support for Java 8 required manually overriding the `JAVA_HOME` -- this way, it all derives from `java:env`
